### PR TITLE
[fix] Fix that RSS is never returned on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function childrenOfPid(pid, includeRoot, callback) {
 
       // Convert RSS to number of bytes
       if (process.platform == 'win32') {
-          // For Windows, WMIC.exe never returns any value for "Status" and it causes "WorkingSetSize" is set at columns[3].
+          // For Windows, WMIC.exe never returns any value for "Status" and it causes "WorkingSetSize" is set at columns[3]
           // See: https://docs.microsoft.com/ja-jp/windows/win32/cimwin32prov/win32-process?redirectedfrom=MSDN
           columns[4] = parseInt(columns[3], 10);
           columns[3] = null;

--- a/index.js
+++ b/index.js
@@ -72,8 +72,14 @@ module.exports = function childrenOfPid(pid, includeRoot, callback) {
       }
 
       // Convert RSS to number of bytes
-      columns[4] = parseInt(columns[4], 10);
-      if (process.platform !== 'win32') {
+      if (process.platform == 'win32') {
+          // For Windows, WMIC.exe never returns any value for "Status" and it causes "WorkingSetSize" is set at columns[3].
+          // See: https://docs.microsoft.com/ja-jp/windows/win32/cimwin32prov/win32-process?redirectedfrom=MSDN
+          columns[4] = parseInt(columns[3], 10);
+          columns[3] = null;
+      }
+      else {
+          columns[4] = parseInt(columns[4], 10);
           columns[4] *= 1024;
       }
 
@@ -122,19 +128,14 @@ function normalizeHeader(str) {
   switch (str) {
     case 'Name':
       return 'COMMAND';
-      break;
     case 'ParentProcessId':
       return 'PPID';
-      break;
     case 'ProcessId':
       return 'PID';
-      break;
     case 'Status':
       return 'STAT';
-      break;
     case 'WorkingSetSize':
       return 'RSS';
-      break;
     default:
       throw new Error('Unknown process listing header: ' + str);
   }

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,9 @@ var red = chalk.red,
     green = chalk.green,
     cyan = chalk.cyan;
 
+var isWin = process.platform === 'win32';
+var isNumGreaterThanZero = (n) => !isNaN(parseInt(n, 10)) && n > 0;
+
 var scripts = {
   parent: path.join(__dirname, 'exec', 'parent.js'),
   child: path.join(__dirname, 'exec', 'child.js')
@@ -65,9 +68,11 @@ test(cyan('Includes itself it includeRoot is true'), function (t) {
     };
 
     t.equal(current.PID, '' + process.pid, green('✓ Current PID is valid'));
-    t.equal(current.COMMAND, 'node', green('✓ Current COMM is node'));
+    t.equal(current.COMMAND, isWin ? 'node.exe' : 'node', green('✓ Current COMM is node'));
+    t.equal(isNumGreaterThanZero(current.RSS), true, green('✓ Current RSS is valid'));
     t.notEqual(other.PID, '' + process.pid, green('✓ Current PID is valid'));
-    t.equal(other.COMMAND, 'ps', green('✓ Current COMM is ps'));
+    t.equal(other.COMMAND, isWin ? 'WMIC.exe' : 'ps', green('✓ Current COMM is ps'));
+    t.equal(isNumGreaterThanZero(other.RSS), true, green('✓ Other RSS is valid'));
     t.end();
   });
 });


### PR DESCRIPTION
RSS is always returned as NaN, and I think it causes that the "mainProcessBytes" in the response of "Apify.getMemoryInfo" is always returned as "NaN" on Windows environment. 