### PR TITLE
move process name to be the last argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,9 +48,9 @@ module.exports = function childrenOfPid(pid, includeRoot, callback) {
   var processLister;
   if (process.platform === 'win32') {
     // See also: https://github.com/nodejs/node-v0.x-archive/issues/2318
-    processLister = spawn('wmic.exe', ['PROCESS', 'GET', 'Name,ProcessId,ParentProcessId,WorkingSetSize']);
+    processLister = spawn('wmic.exe', ['PROCESS', 'GET', 'ProcessId,ParentProcessId,WorkingSetSize,Name']);
   } else {
-    processLister = spawn('ps', ['-A', '-o', 'ppid,pid,stat,comm,rss']);
+    processLister = spawn('ps', ['-A', '-o', 'ppid,pid,stat,rss,comm']);
   }
 
   processLister.on('error', callback);
@@ -73,11 +73,11 @@ module.exports = function childrenOfPid(pid, includeRoot, callback) {
 
       // Convert RSS to number of bytes
       if (process.platform == 'win32') {
-          columns[3] = parseInt(columns[3], 10);
+          columns[2] = parseInt(columns[2], 10);
       }
       else {
-          columns[4] = parseInt(columns[4], 10);
-          columns[4] *= 1024;
+          columns[3] = parseInt(columns[3], 10);
+          columns[3] *= 1024;
       }
 
       var row = {};


### PR DESCRIPTION
Process/command names can have spaces in them. For the below logic (line 87) to work, process name must be the last argument to the ps call.

```js
while (h.length) {
    row[h.shift()] = h.length ? columns.shift() : columns.join(' ');
}
```

I can't quite generate a failing test case on demand at the moment but see the below screenshot, many processes created by Firefox have space character in between.

![Screenshot from 2023-02-21 19-37-41](https://user-images.githubusercontent.com/23482163/220368676-1a1ca40e-eff3-4569-a589-d1e39e135759.png)

